### PR TITLE
feat: added context to isFeatureEnabled

### DIFF
--- a/src/feature-toggle-header-request.interceptor.ts
+++ b/src/feature-toggle-header-request.interceptor.ts
@@ -26,27 +26,11 @@ export class FeatureToggleHeaderRequestInterceptor implements NestInterceptor {
       return next.handle();
     }
 
-    Object.keys(headers)
-      .filter((key) =>
-        key.includes(
-          this.featureToggleService.getHttpContextConfig()
-            ?.keywordToBeSearchedInHeader ?? 'feature_'
-        )
-      )
-      .forEach(async (key) => {
-        const feature: FeatureEntity = features.filter(
-          (feature: FeatureEntity) => {
-            return feature.getName() === key.toUpperCase();
-          }
-        )[0];
-
-        if (
-          typeof feature !== 'undefined' &&
-          feature.isAcceptHTTPRequestContext()
-        ) {
-          feature.setValue(!!parseInt(headers[key] as string));
-        }
-      });
+    FeatureToggleService.setFeaturesFromHeader(
+      headers,
+      features,
+      this.featureToggleService.getHttpContextConfig()
+    );
 
     return next.handle();
   }

--- a/src/interfaces/feature-toggle.service.interface.ts
+++ b/src/interfaces/feature-toggle.service.interface.ts
@@ -1,8 +1,9 @@
+import { ExecutionContext } from '@nestjs/common';
 import FeatureInterface from './feature.interface';
 
 interface FeatureToggleServiceInterface {
-  getFeature(featureName: string): Promise<FeatureInterface> | null;
-  isFeatureEnabled(featureName: string): Promise<boolean> | null;
+  getFeature(featureName: string, context?: ExecutionContext): Promise<FeatureInterface> | null;
+  isFeatureEnabled(featureName: string, context?: ExecutionContext): Promise<boolean> | null;
 }
 
 export default FeatureToggleServiceInterface;

--- a/src/tests/feature-toggle.service.spec.ts
+++ b/src/tests/feature-toggle.service.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '../interfaces/feature-toggle-module-options.interface';
 import { FeatureToggleModule } from '../feature-toggle.module';
 import { FeatureToggleService } from '../feature-toggle.service';
+import { ExecutionContext } from '@nestjs/common';
 
 const setup = async (config: FeatureToggleModuleOptions) => {
   const module = await Test.createTestingModule({
@@ -30,6 +31,25 @@ const config: FeatureToggleModuleOptions = {
       value: false
     }
   ]
+};
+
+const executionContext: ExecutionContext = {
+  switchToHttp: jest.fn(() => ({
+    getRequest: jest.fn().mockReturnValue({
+      headers: {
+        [config.featureSettings[0].name]: '1'
+      }
+    }),
+    getNext: jest.fn().mockReturnThis(),
+    getResponse: jest.fn().mockReturnThis()
+  })),
+  getClass: jest.fn().mockReturnThis(),
+  getHandler: jest.fn().mockReturnThis(),
+  getArgs: jest.fn().mockReturnThis(),
+  getArgByIndex: jest.fn().mockReturnThis(),
+  switchToRpc: jest.fn().mockReturnThis(),
+  switchToWs: jest.fn().mockReturnThis(),
+  getType: jest.fn().mockReturnThis()
 };
 
 describe('Feature Toggle Service', () => {
@@ -73,6 +93,14 @@ describe('Feature Toggle Service', () => {
       expect(
         featureToggleService.getHttpContextConfig()?.keywordToBeSearchedInHeader
       ).toBe(config.httpRequestContext.keywordToBeSearchedInHeader);
+    });
+
+    it('Should check if a feature is enabled by the configuration and context', async () => {
+      let feature = await featureToggleService.getFeature(
+        config.featureSettings[0].name,
+        executionContext
+      );
+      expect(feature.isEnabled()).toBeTruthy()
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
I added a extra param to "isFeatureEnabled" because if you call "isFeatureEnabled" in a guard or middleware you get a wrong anser for feature.

## What is the new behavior?
you can call `isFeatureEnabled("FEATURE_NAME", context)` context is a **ExecutionContext**

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information